### PR TITLE
Add team pace ranking feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -277,6 +277,12 @@ if selected_session_key and selected_driver_number:
                         else:
                             team_fig = visualizers.plot_team_comparison(team_df) #
                             st.plotly_chart(team_fig, use_container_width=True)
+
+                            # Overall team pace ranking
+                            overall_df = processing.overall_team_pace(filtered_laps_list)
+                            if not overall_df.empty:
+                                pace_fig = visualizers.plot_team_pace(overall_df)
+                                st.plotly_chart(pace_fig, use_container_width=True)
             except Exception as e:
                 logger.error(f"Error in team comparison tab: {e}")
                 st.error(f"Error rendering team comparison: {str(e)}")

--- a/processing.py
+++ b/processing.py
@@ -143,6 +143,30 @@ def team_pace_stats(laps: List[Dict[str, Any]]) -> pd.DataFrame:
     return team_stats
 
 
+def overall_team_pace(laps: List[Dict[str, Any]]) -> pd.DataFrame:
+    """Aggregate average pace per team."""
+    if not laps:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(laps)
+    df["lap_duration_seconds"] = df["lap_duration"].apply(convert_time_to_seconds)
+
+    valid_df = df[
+        (df["lap_duration_seconds"].notna())
+        & (df["lap_duration_seconds"] > 0)
+        & (~df.get("is_pit_out_lap", False))
+    ]
+
+    if valid_df.empty:
+        return pd.DataFrame()
+
+    team_avg = (
+        valid_df.groupby("team_name")["lap_duration_seconds"].mean().reset_index()
+    )
+
+    return team_avg.sort_values("lap_duration_seconds")
+
+
 def tyre_degradation(laps: List[Dict[str, Any]], stints: List[Dict[str, Any]]) -> pd.DataFrame:
     """Analyze tyre degradation patterns."""
     if not laps or not stints:

--- a/visualizers.py
+++ b/visualizers.py
@@ -181,6 +181,37 @@ def plot_team_comparison(df: pd.DataFrame) -> Figure:
     return fig
 
 
+def plot_team_pace(df: pd.DataFrame) -> Figure:
+    """Bar chart ranking teams by average pace."""
+    if df.empty or 'team_name' not in df.columns:
+        return go.Figure().add_annotation(
+            text="No team pace data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
+    colors = [TEAM_COLORS.get(team, "#888888") for team in df["team_name"]]
+    fig = go.Figure()
+    fig.add_bar(
+        x=df["team_name"],
+        y=df["lap_duration_seconds"],
+        marker_color=colors,
+        text=[f"{t:.3f}s" for t in df["lap_duration_seconds"]],
+        textposition="outside",
+    )
+    fig.update_layout(
+        title="🚥 Team Pace Ranking",
+        xaxis_title="Team",
+        yaxis_title="Average Lap Time (seconds)",
+        template="plotly_white",
+        xaxis_tickangle=-45,
+    )
+    return fig
+
+
 def plot_pace_by_compound(df: pd.DataFrame) -> Figure:
     """Box plot showing pace by tyre compound."""
     if df.empty:


### PR DESCRIPTION
## Summary
- analyze and rank overall team pace
- show team pace ranking chart in the Streamlit UI

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdb96cd408327b274d8107ccf31c4