### PR TITLE
Refactor visualizers and data loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import pandas as pd
 import logging
+
 # Assuming api.py, processing.py, visualizers.py are in the same directory or accessible
 import api
 import processing
@@ -16,40 +17,44 @@ st.set_page_config(page_title="F1 Performance Dashboard", page_icon="🏁", layo
 st.sidebar.title("🔍 Controls")
 selected_year = st.sidebar.selectbox(
     "Select Year:",
-    options=[2024, 2023], # Years mentioned in original app.py
-    index=0  # Default to 2024
+    options=[2024, 2023],  # Years mentioned in original app.py
+    index=0,  # Default to 2024
 )
+
 
 # --- Functions to fetch data for dropdowns (adapted from Dash callbacks) ---
 def get_meeting_options(year):
     if not year:
         return [], None
     try:
-        meetings = api.get_meetings(year) # API call
+        meetings = api.get_meetings(year)  # API call
         # Create a dictionary of display label to meeting_key
-        options = {f"{m.meeting_name} ({m.meeting_country})": m.meeting_key for m in meetings}
+        options = {
+            f"{m.meeting_name} ({m.meeting_country})": m.meeting_key for m in meetings
+        }
         # Default to the last meeting if available, as in original app.py
         default_key = meetings[-1].meeting_key if meetings else None
-        default_label = next((label for label, key in options.items() if key == default_key), None)
+        default_label = next(
+            (label for label, key in options.items() if key == default_key), None
+        )
         return options, default_label
     except Exception as e:
         logger.error(f"Error loading meetings: {e}")
         st.sidebar.error(f"Error loading meetings for {year}.")
         return {}, None
 
+
 meeting_options, default_meeting_label = get_meeting_options(selected_year)
-selected_meeting_key = None # Initialize
+selected_meeting_key = None  # Initialize
 if meeting_options:
     # Determine index for default selection
     options_list = list(meeting_options.keys())
     default_index = 0
     if default_meeting_label and default_meeting_label in options_list:
         default_index = options_list.index(default_meeting_label)
-    
+
     selected_meeting_label = st.sidebar.selectbox(
-        "Select Grand Prix:",
-        options=options_list,
-        index=default_index
+        "Select Grand Prix:", options=options_list, index=default_index
     )
     selected_meeting_key = meeting_options.get(selected_meeting_label)
 else:
@@ -60,19 +65,30 @@ def get_session_options(meeting_key):
     if not meeting_key:
         return {}, None
     try:
-        sessions = api.get_sessions(meeting_key) # API call
-        options = {f"{s.session_name} ({s.session_type})": s.session_key for s in sessions}
+        sessions = api.get_sessions(meeting_key)  # API call
+        options = {
+            f"{s.session_name} ({s.session_type})": s.session_key for s in sessions
+        }
         # Prefer race session or last session, as in original app.py
-        race_session = next((s for s in sessions if 'race' in s.session_name.lower()), None)
-        default_key = race_session.session_key if race_session else (sessions[-1].session_key if sessions else None)
-        default_label = next((label for label, key in options.items() if key == default_key), None)
+        race_session = next(
+            (s for s in sessions if "race" in s.session_name.lower()), None
+        )
+        default_key = (
+            race_session.session_key
+            if race_session
+            else (sessions[-1].session_key if sessions else None)
+        )
+        default_label = next(
+            (label for label, key in options.items() if key == default_key), None
+        )
         return options, default_label
     except Exception as e:
         logger.error(f"Error loading sessions: {e}")
         st.sidebar.error(f"Error loading sessions for meeting key {meeting_key}.")
         return {}, None
 
-selected_session_key = None # Initialize
+
+selected_session_key = None  # Initialize
 if selected_meeting_key:
     session_options, default_session_label = get_session_options(selected_meeting_key)
     if session_options:
@@ -82,36 +98,41 @@ if selected_meeting_key:
             default_index = options_list.index(default_session_label)
 
         selected_session_label = st.sidebar.selectbox(
-            "Select Session:",
-            options=options_list,
-            index=default_index
+            "Select Session:", options=options_list, index=default_index
         )
         selected_session_key = session_options.get(selected_session_label)
     else:
         st.sidebar.warning("No sessions found for the selected Grand Prix.")
 else:
-    if selected_year and not meeting_options: # Only show if year was selected but no meetings
-        pass # Warning already shown by get_meeting_options
-    elif selected_year and meeting_options and not selected_meeting_key :
-         st.sidebar.info("Select a Grand Prix.")
+    if (
+        selected_year and not meeting_options
+    ):  # Only show if year was selected but no meetings
+        pass  # Warning already shown by get_meeting_options
+    elif selected_year and meeting_options and not selected_meeting_key:
+        st.sidebar.info("Select a Grand Prix.")
 
 
 def get_driver_options(session_key):
     if not session_key:
         return {}, None
     try:
-        drivers = api.get_drivers(session_key) # API call
-        options = {f"{d.broadcast_name} ({d.team_name})": d.driver_number for d in drivers}
+        drivers = api.get_drivers(session_key)  # API call
+        options = {
+            f"{d.broadcast_name} ({d.team_name})": d.driver_number for d in drivers
+        }
         # Default to the first driver if available, as in original app.py
         default_key = drivers[0].driver_number if drivers else None
-        default_label = next((label for label, key in options.items() if key == default_key), None)
+        default_label = next(
+            (label for label, key in options.items() if key == default_key), None
+        )
         return options, default_label
     except Exception as e:
         logger.error(f"Error loading drivers: {e}")
         st.sidebar.error(f"Error loading drivers for session key {session_key}.")
         return {}, None
 
-selected_driver_number = None # Initialize
+
+selected_driver_number = None  # Initialize
 if selected_session_key:
     driver_options, default_driver_label = get_driver_options(selected_session_key)
     if driver_options:
@@ -119,121 +140,176 @@ if selected_session_key:
         default_index = 0
         if default_driver_label and default_driver_label in options_list:
             default_index = options_list.index(default_driver_label)
-            
+
         selected_driver_label = st.sidebar.selectbox(
-            "Select Driver:",
-            options=options_list,
-            index=default_index
+            "Select Driver:", options=options_list, index=default_index
         )
         selected_driver_number = driver_options.get(selected_driver_label)
     else:
         st.sidebar.warning("No drivers found for the selected session.")
 else:
     if selected_meeting_key and not selected_session_key:
-        pass # Warning already shown by get_session_options
-    elif selected_meeting_key and selected_session_key and selected_driver_number is None:
+        pass  # Warning already shown by get_session_options
+    elif (
+        selected_meeting_key and selected_session_key and selected_driver_number is None
+    ):
         st.sidebar.info("Select a Session with drivers.")
 
 
 # --- Main Page Layout ---
 st.title("F1 Performance Dashboard")
-st.markdown("Real-time F1 telemetry and performance analysis using OpenF1 API") #
+st.markdown("Real-time F1 telemetry and performance analysis using OpenF1 API")  #
 
 # --- Key Metrics ---
 if selected_session_key and selected_driver_number:
     st.header("📊 Key Metrics")
     try:
-        with st.spinner("Loading key metrics..."): # Loading indicator
-            laps_data = api.get_laps(selected_session_key, selected_driver_number) # API call
+        with st.spinner("Loading key metrics..."):  # Loading indicator
+            laps_data = api.get_laps(
+                selected_session_key, selected_driver_number
+            )  # API call
             if not laps_data:
                 st.warning("No lap data available for key metrics.")
             else:
-                # The processing.lap_stats function expects a list of dicts
-                stats = processing.lap_stats([lap.dict() for lap in laps_data]) 
-                
+                laps_df_metrics = api.models_to_dataframe(laps_data)
+                stats = processing.lap_stats(laps_df_metrics.to_dict("records"))
+
                 cols = st.columns(4)
-                cols[0].metric(label="Fastest Lap", value=stats.get('fastest', 'N/A'))
-                cols[1].metric(label="Average Lap", value=stats.get('average', 'N/A'))
+                cols[0].metric(label="Fastest Lap", value=stats.get("fastest", "N/A"))
+                cols[1].metric(label="Average Lap", value=stats.get("average", "N/A"))
                 cols[2].metric(label="Total Laps", value=str(len(laps_data)))
-                consistency_val = stats.get('consistency', 0)
-                consistency_str = f"{consistency_val:.2f}%" if isinstance(consistency_val, (float, int)) else "N/A"
+                consistency_val = stats.get("consistency", 0)
+                consistency_str = (
+                    f"{consistency_val:.2f}%"
+                    if isinstance(consistency_val, (float, int))
+                    else "N/A"
+                )
                 cols[3].metric(label="Consistency", value=consistency_str)
 
     except Exception as e:
         logger.error(f"Error updating key metrics: {e}")
         st.error(f"Error loading key metrics: {str(e)}")
 else:
-    st.info("ℹ️ Please select a year, Grand Prix, session, and driver from the sidebar to view metrics and charts.")
+    st.info(
+        "ℹ️ Please select a year, Grand Prix, session, and driver from the sidebar to view metrics and charts."
+    )
 
 
 # --- Tabs for Charts ---
 if selected_session_key and selected_driver_number:
     st.header("Analysis Tabs")
     # Tab structure from original app.py
-    tab1, tab2, tab3, tab4 = st.tabs(["Lap Analysis", "Team Comparison", "Tyre Analysis", "Advanced"])
+    tab1, tab2, tab3, tab4 = st.tabs(
+        ["Lap Analysis", "Team Comparison", "Tyre Analysis", "Advanced"]
+    )
 
-    with st.spinner("Loading charts..."): # Loading indicator
+    with st.spinner("Loading charts..."):  # Loading indicator
         with tab1:
             st.subheader("Lap Analysis")
             try:
-                laps = api.get_laps(selected_session_key, selected_driver_number) # API call
+                laps = api.get_laps(
+                    selected_session_key, selected_driver_number
+                )  # API call
                 if not laps:
                     st.warning("No lap data available for the selected driver.")
                 else:
-                    laps_df = pd.DataFrame([lap.dict() for lap in laps]) # Convert Pydantic models to DataFrame
-                    
+                    laps_df = api.models_to_dataframe(laps)
+
                     # Ensure 'lap_duration' (numeric, seconds) is present for visualizers/processing
-                    if 'lap_duration' not in laps_df.columns and 'lap_duration_seconds' in laps_df.columns:
-                         laps_df['lap_duration'] = laps_df['lap_duration_seconds']
-                    elif 'lap_duration' not in laps_df.columns: # If neither, attempt conversion if it's string time
-                        laps_df['lap_duration'] = laps_df['lap_duration'].apply(processing.convert_time_to_seconds)
+                    if (
+                        "lap_duration" not in laps_df.columns
+                        and "lap_duration_seconds" in laps_df.columns
+                    ):
+                        laps_df["lap_duration"] = laps_df["lap_duration_seconds"]
+                    elif (
+                        "lap_duration" not in laps_df.columns
+                    ):  # If neither, attempt conversion if it's string time
+                        laps_df["lap_duration"] = laps_df["lap_duration"].apply(
+                            processing.convert_time_to_seconds
+                        )
 
-
-                    if 'lap_duration' in laps_df.columns and not laps_df['lap_duration'].isna().all():
-                        lap_trend_fig = visualizers.plot_lap_trend(laps_df) #
+                    if (
+                        "lap_duration" in laps_df.columns
+                        and not laps_df["lap_duration"].isna().all()
+                    ):
+                        lap_trend_fig = visualizers.plot_lap_trend(laps_df)  #
                         st.plotly_chart(lap_trend_fig, use_container_width=True)
-                        
-                        distribution_fig = visualizers.plot_distribution(laps_df) #
+
+                        distribution_fig = visualizers.plot_distribution(laps_df)  #
                         st.plotly_chart(distribution_fig, use_container_width=True)
                     else:
                         st.warning("Lap duration data missing or invalid for charts.")
 
                     # Teammate comparison (within lap analysis)
                     st.subheader("Teammate Delta")
-                    drivers = api.get_drivers(selected_session_key) # API call
-                    selected_driver_details = next((d for d in drivers if d.driver_number == selected_driver_number), None)
+                    drivers = api.get_drivers(selected_session_key)  # API call
+                    selected_driver_details = next(
+                        (
+                            d
+                            for d in drivers
+                            if d.driver_number == selected_driver_number
+                        ),
+                        None,
+                    )
                     teammate = None
                     if selected_driver_details:
-                        teammate = next((d for d in drivers 
-                                       if d.team_name == selected_driver_details.team_name and d.driver_number != selected_driver_number), 
-                                      None)
-                    
+                        teammate = next(
+                            (
+                                d
+                                for d in drivers
+                                if d.team_name == selected_driver_details.team_name
+                                and d.driver_number != selected_driver_number
+                            ),
+                            None,
+                        )
+
                     if teammate:
-                        teammate_laps_data = api.get_laps(selected_session_key, teammate.driver_number) # API call
+                        teammate_laps_data = api.get_laps(
+                            selected_session_key, teammate.driver_number
+                        )  # API call
                         if teammate_laps_data:
-                            teammate_df = pd.DataFrame([lap.dict() for lap in teammate_laps_data])
-                            
+                            teammate_df = api.models_to_dataframe(teammate_laps_data)
+
                             # Ensure 'lap_duration' (numeric, seconds) for processing
                             for df_to_check in [laps_df, teammate_df]:
-                                if 'lap_duration' not in df_to_check.columns and 'lap_duration_seconds' in df_to_check.columns:
-                                    df_to_check['lap_duration'] = df_to_check['lap_duration_seconds']
-                                elif 'lap_duration' not in df_to_check.columns:
-                                     df_to_check['lap_duration'] = df_to_check['lap_duration'].apply(processing.convert_time_to_seconds)
+                                if (
+                                    "lap_duration" not in df_to_check.columns
+                                    and "lap_duration_seconds" in df_to_check.columns
+                                ):
+                                    df_to_check["lap_duration"] = df_to_check[
+                                        "lap_duration_seconds"
+                                    ]
+                                elif "lap_duration" not in df_to_check.columns:
+                                    df_to_check["lap_duration"] = df_to_check[
+                                        "lap_duration"
+                                    ].apply(processing.convert_time_to_seconds)
 
-
-                            if 'lap_duration' in laps_df.columns and 'lap_duration' in teammate_df.columns:
-                                delta_df = processing.teammate_deltas(laps_df, teammate_df) #
+                            if (
+                                "lap_duration" in laps_df.columns
+                                and "lap_duration" in teammate_df.columns
+                            ):
+                                delta_df = processing.teammate_deltas(
+                                    laps_df, teammate_df
+                                )  #
                                 if not delta_df.empty:
-                                    delta_fig = visualizers.plot_delta(delta_df) #
+                                    delta_fig = visualizers.plot_delta(delta_df)  #
                                     st.plotly_chart(delta_fig, use_container_width=True)
                                 else:
-                                    st.info("No comparable laps found between teammates for delta analysis.")
+                                    st.info(
+                                        "No comparable laps found between teammates for delta analysis."
+                                    )
                             else:
-                                st.warning("Lap duration data missing for selected driver or teammate, cannot calculate delta.")
+                                st.warning(
+                                    "Lap duration data missing for selected driver or teammate, cannot calculate delta."
+                                )
                         else:
-                            st.info(f"No lap data found for teammate ({teammate.broadcast_name}).")
+                            st.info(
+                                f"No lap data found for teammate ({teammate.broadcast_name})."
+                            )
                     else:
-                        st.info("No teammate found for comparison or selected driver details missing.")
+                        st.info(
+                            "No teammate found for comparison or selected driver details missing."
+                        )
 
             except Exception as e:
                 logger.error(f"Error in lap analysis tab: {e}")
@@ -242,44 +318,70 @@ if selected_session_key and selected_driver_number:
         with tab2:
             st.subheader("Team Comparison")
             try:
-                all_laps_data = api.get_laps(selected_session_key) # API call
+                all_laps_data = api.get_laps(selected_session_key)  # API call
                 if not all_laps_data:
                     st.warning("No lap data available for team comparison.")
                 else:
-                    all_laps_list = [lap.dict() for lap in all_laps_data]
-                    
+                    all_laps_df = api.models_to_dataframe(all_laps_data)
+                    all_laps_list = all_laps_df.to_dict("records")
+
                     # Add team_name to laps, as processing.team_pace_stats needs it
                     # Lap model itself doesn't have team_name
-                    drivers_list_for_teams = api.get_drivers(selected_session_key) # API call
-                    driver_to_team_map = {d.driver_number: d.team_name for d in drivers_list_for_teams}
+                    drivers_list_for_teams = api.get_drivers(
+                        selected_session_key
+                    )  # API call
+                    driver_to_team_map = {
+                        d.driver_number: d.team_name for d in drivers_list_for_teams
+                    }
 
                     for lap_dict in all_laps_list:
-                        if 'team_name' not in lap_dict or pd.isna(lap_dict.get('team_name')):
-                            lap_dict['team_name'] = driver_to_team_map.get(lap_dict['driver_number'])
+                        if "team_name" not in lap_dict or pd.isna(
+                            lap_dict.get("team_name")
+                        ):
+                            lap_dict["team_name"] = driver_to_team_map.get(
+                                lap_dict["driver_number"]
+                            )
                         # Ensure 'lap_duration' is numeric (seconds)
-                        if 'lap_duration' not in lap_dict and 'lap_duration_seconds' in lap_dict:
-                             lap_dict['lap_duration'] = lap_dict['lap_duration_seconds']
-                        elif 'lap_duration' in lap_dict and not isinstance(lap_dict['lap_duration'], (int, float)):
-                            lap_dict['lap_duration'] = processing.convert_time_to_seconds(lap_dict['lap_duration'])
-
+                        if (
+                            "lap_duration" not in lap_dict
+                            and "lap_duration_seconds" in lap_dict
+                        ):
+                            lap_dict["lap_duration"] = lap_dict["lap_duration_seconds"]
+                        elif "lap_duration" in lap_dict and not isinstance(
+                            lap_dict["lap_duration"], (int, float)
+                        ):
+                            lap_dict["lap_duration"] = (
+                                processing.convert_time_to_seconds(
+                                    lap_dict["lap_duration"]
+                                )
+                            )
 
                     # Filter out laps without team_name or valid lap_duration
                     filtered_laps_list = [
-                        lap for lap in all_laps_list if lap.get('team_name') and pd.notna(lap.get('team_name')) and 'lap_duration' in lap and pd.notna(lap['lap_duration'])
+                        lap
+                        for lap in all_laps_list
+                        if lap.get("team_name")
+                        and pd.notna(lap.get("team_name"))
+                        and "lap_duration" in lap
+                        and pd.notna(lap["lap_duration"])
                     ]
 
                     if not filtered_laps_list:
-                         st.warning("Insufficient data for team pace stats after attempting to map team names and validate lap durations.")
+                        st.warning(
+                            "Insufficient data for team pace stats after attempting to map team names and validate lap durations."
+                        )
                     else:
-                        team_df = processing.team_pace_stats(filtered_laps_list) #
+                        team_df = processing.team_pace_stats(filtered_laps_list)  #
                         if team_df.empty:
                             st.info("No team comparison data could be processed.")
                         else:
-                            team_fig = visualizers.plot_team_comparison(team_df) #
+                            team_fig = visualizers.plot_team_comparison(team_df)  #
                             st.plotly_chart(team_fig, use_container_width=True)
 
                             # Overall team pace ranking
-                            overall_df = processing.overall_team_pace(filtered_laps_list)
+                            overall_df = processing.overall_team_pace(
+                                filtered_laps_list
+                            )
                             if not overall_df.empty:
                                 pace_fig = visualizers.plot_team_pace(overall_df)
                                 st.plotly_chart(pace_fig, use_container_width=True)
@@ -290,45 +392,71 @@ if selected_session_key and selected_driver_number:
         with tab3:
             st.subheader("Tyre Analysis")
             try:
-                all_laps_data_tyre = api.get_laps(selected_session_key) # API call
-                stints_data = api.get_stints(selected_session_key) # API call
+                all_laps_data_tyre = api.get_laps(selected_session_key)  # API call
+                stints_data = api.get_stints(selected_session_key)  # API call
 
                 if not all_laps_data_tyre or not stints_data:
                     st.warning("No tyre data (laps or stints) available.")
                 else:
-                    all_laps_list_tyre = [lap.dict() for lap in all_laps_data_tyre]
-                    stints_list = [stint.dict() for stint in stints_data]
+                    all_laps_df_tyre = api.models_to_dataframe(all_laps_data_tyre)
+                    stints_df = api.models_to_dataframe(stints_data)
+                    all_laps_list_tyre = all_laps_df_tyre.to_dict("records")
+                    stints_list = stints_df.to_dict("records")
 
                     # Ensure 'lap_duration' is numeric (seconds) in all_laps_list_tyre
                     for lap_dict in all_laps_list_tyre:
-                        if 'lap_duration' not in lap_dict and 'lap_duration_seconds' in lap_dict:
-                             lap_dict['lap_duration'] = lap_dict['lap_duration_seconds']
-                        elif 'lap_duration' in lap_dict and not isinstance(lap_dict['lap_duration'], (int, float)):
-                            lap_dict['lap_duration'] = processing.convert_time_to_seconds(lap_dict['lap_duration'])
-                    
-                    filtered_laps_list_tyre = [lap for lap in all_laps_list_tyre if 'lap_duration' in lap and pd.notna(lap['lap_duration'])]
+                        if (
+                            "lap_duration" not in lap_dict
+                            and "lap_duration_seconds" in lap_dict
+                        ):
+                            lap_dict["lap_duration"] = lap_dict["lap_duration_seconds"]
+                        elif "lap_duration" in lap_dict and not isinstance(
+                            lap_dict["lap_duration"], (int, float)
+                        ):
+                            lap_dict["lap_duration"] = (
+                                processing.convert_time_to_seconds(
+                                    lap_dict["lap_duration"]
+                                )
+                            )
+
+                    filtered_laps_list_tyre = [
+                        lap
+                        for lap in all_laps_list_tyre
+                        if "lap_duration" in lap and pd.notna(lap["lap_duration"])
+                    ]
 
                     if not filtered_laps_list_tyre:
-                        st.warning("Insufficient lap data for tyre degradation analysis after filtering.")
+                        st.warning(
+                            "Insufficient lap data for tyre degradation analysis after filtering."
+                        )
                     else:
-                        tyre_df = processing.tyre_degradation(filtered_laps_list_tyre, stints_list) #
-                        
+                        tyre_df = processing.tyre_degradation(
+                            filtered_laps_list_tyre, stints_list
+                        )  #
+
                         if tyre_df.empty:
                             st.info("No tyre degradation data could be processed.")
                         else:
-                            compound_fig = visualizers.plot_pace_by_compound(tyre_df) #
+                            compound_fig = visualizers.plot_pace_by_compound(tyre_df)  #
                             st.plotly_chart(compound_fig, use_container_width=True)
-                            
-                            degradation_fig = visualizers.plot_degradation_curves(tyre_df) #
+
+                            degradation_fig = visualizers.plot_degradation_curves(
+                                tyre_df
+                            )  #
                             st.plotly_chart(degradation_fig, use_container_width=True)
-                        
+
                     # Stint timeline (can be plotted even if tyre_df is empty if stints_data exists)
-                    stint_df_vis = pd.DataFrame(stints_list) # Stint model has lap_start, lap_end, driver_number, compound
-                    if not stint_df_vis.empty and all(col in stint_df_vis.columns for col in ['lap_start', 'lap_end', 'driver_number', 'compound']):
-                        timeline_fig = visualizers.plot_stint_timeline(stint_df_vis) #
+                    stint_df_vis = stints_df  # Stint model has lap_start, lap_end, driver_number, compound
+                    if not stint_df_vis.empty and all(
+                        col in stint_df_vis.columns
+                        for col in ["lap_start", "lap_end", "driver_number", "compound"]
+                    ):
+                        timeline_fig = visualizers.plot_stint_timeline(stint_df_vis)  #
                         st.plotly_chart(timeline_fig, use_container_width=True)
                     else:
-                        st.info("No valid stint data for timeline (missing required columns or empty).")
+                        st.info(
+                            "No valid stint data for timeline (missing required columns or empty)."
+                        )
 
             except Exception as e:
                 logger.error(f"Error in tyre analysis tab: {e}")
@@ -337,109 +465,185 @@ if selected_session_key and selected_driver_number:
         with tab4:
             st.subheader("Advanced Analysis")
             try:
-                driver_laps_data_adv = api.get_laps(selected_session_key, selected_driver_number) # API call
-                all_laps_data_adv = api.get_laps(selected_session_key) # API call
+                driver_laps_data_adv = api.get_laps(
+                    selected_session_key, selected_driver_number
+                )  # API call
+                all_laps_data_adv = api.get_laps(selected_session_key)  # API call
 
                 if not driver_laps_data_adv:
                     st.warning("No driver data available for advanced metrics.")
                 else:
-                    driver_laps_list_adv = [lap.dict() for lap in driver_laps_data_adv]
+                    driver_laps_df_adv = api.models_to_dataframe(driver_laps_data_adv)
+                    driver_laps_list_adv = driver_laps_df_adv.to_dict("records")
                     # Ensure 'lap_duration' is numeric (seconds)
                     for lap_dict in driver_laps_list_adv:
-                         if 'lap_duration' not in lap_dict and 'lap_duration_seconds' in lap_dict:
-                             lap_dict['lap_duration'] = lap_dict['lap_duration_seconds']
-                         elif 'lap_duration' in lap_dict and not isinstance(lap_dict['lap_duration'], (int, float)):
-                            lap_dict['lap_duration'] = processing.convert_time_to_seconds(lap_dict['lap_duration'])
+                        if (
+                            "lap_duration" not in lap_dict
+                            and "lap_duration_seconds" in lap_dict
+                        ):
+                            lap_dict["lap_duration"] = lap_dict["lap_duration_seconds"]
+                        elif "lap_duration" in lap_dict and not isinstance(
+                            lap_dict["lap_duration"], (int, float)
+                        ):
+                            lap_dict["lap_duration"] = (
+                                processing.convert_time_to_seconds(
+                                    lap_dict["lap_duration"]
+                                )
+                            )
 
-                    
-                    filtered_driver_laps_adv = [lap for lap in driver_laps_list_adv if 'lap_duration' in lap and pd.notna(lap['lap_duration'])]
+                    filtered_driver_laps_adv = [
+                        lap
+                        for lap in driver_laps_list_adv
+                        if "lap_duration" in lap and pd.notna(lap["lap_duration"])
+                    ]
 
                     if filtered_driver_laps_adv:
-                        advanced_stats = processing.advanced_performance_metrics(filtered_driver_laps_adv) #
+                        advanced_stats = processing.advanced_performance_metrics(
+                            filtered_driver_laps_adv
+                        )  #
                         if advanced_stats:
                             st.markdown("#### Advanced Performance Metrics")
                             cols_adv = st.columns(2)
-                            cols_adv[0].markdown(f"**Race Pace:** {advanced_stats.get('race_pace', 'N/A')}")
-                            cols_adv[0].markdown(f"**Qualifying Pace:** {advanced_stats.get('qualifying_pace', 'N/A')}")
-                            cols_adv[1].markdown(f"**10th Percentile:** {advanced_stats.get('p10_laptime', 'N/A')}")
-                            cols_adv[1].markdown(f"**90th Percentile:** {advanced_stats.get('p90_laptime', 'N/A')}")
+                            cols_adv[0].markdown(
+                                f"**Race Pace:** {advanced_stats.get('race_pace', 'N/A')}"
+                            )
+                            cols_adv[0].markdown(
+                                f"**Qualifying Pace:** {advanced_stats.get('qualifying_pace', 'N/A')}"
+                            )
+                            cols_adv[1].markdown(
+                                f"**10th Percentile:** {advanced_stats.get('p10_laptime', 'N/A')}"
+                            )
+                            cols_adv[1].markdown(
+                                f"**90th Percentile:** {advanced_stats.get('p90_laptime', 'N/A')}"
+                            )
                         else:
-                            st.info("Could not compute advanced performance metrics for the driver.")
+                            st.info(
+                                "Could not compute advanced performance metrics for the driver."
+                            )
                     else:
-                         st.warning("Insufficient driver lap data for advanced metrics after filtering (missing valid lap_duration).")
-
+                        st.warning(
+                            "Insufficient driver lap data for advanced metrics after filtering (missing valid lap_duration)."
+                        )
 
                 # Sector analysis
                 if all_laps_data_adv:
-                    all_laps_list_adv = [lap.dict() for lap in all_laps_data_adv]
+                    all_laps_df_adv = api.models_to_dataframe(all_laps_data_adv)
+                    all_laps_list_adv = all_laps_df_adv.to_dict("records")
                     # processing.sector_stats expects duration_sector_1, etc. which are in Lap model
-                    
+
                     # Quick check for required sector columns in a sample lap if data exists
                     required_sector_cols_present = True
                     if all_laps_list_adv:
                         sample_lap = all_laps_list_adv[0]
-                        for i in [1,2,3]:
-                            if f'duration_sector_{i}' not in sample_lap:
+                        for i in [1, 2, 3]:
+                            if f"duration_sector_{i}" not in sample_lap:
                                 required_sector_cols_present = False
                                 break
-                    
+
                     if not all_laps_list_adv or not required_sector_cols_present:
-                        st.warning("Sector duration data missing from laps, cannot perform sector analysis.")
+                        st.warning(
+                            "Sector duration data missing from laps, cannot perform sector analysis."
+                        )
                     else:
                         try:
                             # Ensure driver_number is present for grouping in sector_stats
-                            laps_with_driver = [lap for lap in all_laps_list_adv if 'driver_number' in lap]
+                            laps_with_driver = [
+                                lap
+                                for lap in all_laps_list_adv
+                                if "driver_number" in lap
+                            ]
                             if not laps_with_driver:
-                                st.warning("Driver number missing from lap data, cannot perform sector analysis.")
+                                st.warning(
+                                    "Driver number missing from lap data, cannot perform sector analysis."
+                                )
                             else:
-                                sector_df = processing.sector_stats(laps_with_driver) #
+                                sector_df = processing.sector_stats(laps_with_driver)  #
                                 if not sector_df.empty:
                                     st.markdown("#### ⏱️ Sector Analysis")
                                     # visualizers.plot_sector_table might need 'driver_number' and sector columns
-                                    if 'driver_number' in sector_df.columns and all(f'best_s{i}' in sector_df.columns for i in [1,2,3]):
-                                        sector_fig = visualizers.plot_sector_table(sector_df)
-                                        st.plotly_chart(sector_fig, use_container_width=True)
+                                    if "driver_number" in sector_df.columns and all(
+                                        f"best_s{i}" in sector_df.columns
+                                        for i in [1, 2, 3]
+                                    ):
+                                        sector_fig = visualizers.plot_sector_table(
+                                            sector_df
+                                        )
+                                        st.plotly_chart(
+                                            sector_fig, use_container_width=True
+                                        )
                                     else:
-                                        st.warning("Processed sector data is missing required columns (driver_number, best_s1/2/3) for visualization.")
+                                        st.warning(
+                                            "Processed sector data is missing required columns (driver_number, best_s1/2/3) for visualization."
+                                        )
                                 else:
                                     st.info("No sector stats could be processed.")
                         except Exception as e_sector:
                             logger.warning(f"Sector analysis failed: {e_sector}")
-                            st.warning(f"Sector analysis could not be completed: {e_sector}")
+                            st.warning(
+                                f"Sector analysis could not be completed: {e_sector}"
+                            )
                 else:
                     st.warning("No lap data available for sector analysis.")
 
-
                 # Pit stop analysis
                 try:
-                    pits_data = api.get_pits(selected_session_key) # API call
+                    pits_data = api.get_pits(selected_session_key)  # API call
                     if pits_data:
-                        pit_list = [pit.dict() for pit in pits_data]
+                        pit_df_raw = api.models_to_dataframe(pits_data)
+                        pit_list = pit_df_raw.to_dict("records")
                         # processing.pit_stats expects 'pit_duration'
                         # Pit model has pit_duration
                         for pit_dict in pit_list:
-                             if 'pit_duration' not in pit_dict and pit_dict.get('pit_duration_seconds') is not None:
-                                 pit_dict['pit_duration'] = pit_dict['pit_duration_seconds']
-                             elif 'pit_duration' in pit_dict and not isinstance(pit_dict['pit_duration'], (int,float)):
-                                 pit_dict['pit_duration'] = processing.convert_time_to_seconds(pit_dict['pit_duration'])
+                            if (
+                                "pit_duration" not in pit_dict
+                                and pit_dict.get("pit_duration_seconds") is not None
+                            ):
+                                pit_dict["pit_duration"] = pit_dict[
+                                    "pit_duration_seconds"
+                                ]
+                            elif "pit_duration" in pit_dict and not isinstance(
+                                pit_dict["pit_duration"], (int, float)
+                            ):
+                                pit_dict["pit_duration"] = (
+                                    processing.convert_time_to_seconds(
+                                        pit_dict["pit_duration"]
+                                    )
+                                )
 
-
-                        filtered_pit_list = [pit for pit in pit_list if 'pit_duration' in pit and pd.notna(pit['pit_duration']) and 'driver_number' in pit]
+                        filtered_pit_list = [
+                            pit
+                            for pit in pit_list
+                            if "pit_duration" in pit
+                            and pd.notna(pit["pit_duration"])
+                            and "driver_number" in pit
+                        ]
 
                         if filtered_pit_list:
-                            pit_df = processing.pit_stats(filtered_pit_list) #
+                            pit_df = processing.pit_stats(filtered_pit_list)  #
                             if not pit_df.empty:
                                 st.markdown("#### 🔧 Pit Stop Analysis")
                                 # visualizers.plot_pit_durations expects 'driver_number', 'avg_pit', 'min_pit', 'max_pit'
-                                if all(col in pit_df.columns for col in ['driver_number', 'avg_pit', 'min_pit', 'max_pit']):
+                                if all(
+                                    col in pit_df.columns
+                                    for col in [
+                                        "driver_number",
+                                        "avg_pit",
+                                        "min_pit",
+                                        "max_pit",
+                                    ]
+                                ):
                                     pit_fig = visualizers.plot_pit_durations(pit_df)
                                     st.plotly_chart(pit_fig, use_container_width=True)
                                 else:
-                                    st.warning("Processed pit data is missing required columns for visualization.")
+                                    st.warning(
+                                        "Processed pit data is missing required columns for visualization."
+                                    )
                             else:
                                 st.info("No pit stats could be processed.")
                         else:
-                            st.warning("Insufficient pit data after filtering (missing 'pit_duration' or 'driver_number').")
+                            st.warning(
+                                "Insufficient pit data after filtering (missing 'pit_duration' or 'driver_number')."
+                            )
                     else:
                         st.info("No pit data available for this session.")
                 except Exception as e_pit:
@@ -451,20 +655,22 @@ if selected_session_key and selected_driver_number:
                 st.error(f"Error rendering advanced analysis: {str(e)}")
 
 else:
-    if not (selected_session_key and selected_driver_number): # Only show if controls not fully selected
+    if not (
+        selected_session_key and selected_driver_number
+    ):  # Only show if controls not fully selected
         st.info("📊 Select all options from the sidebar to see detailed analysis.")
 
 
 # --- Footer ---
 st.markdown("---")
-st.markdown("Data provided by OpenF1 API | Dashboard built with Streamlit/Plotly") #
+st.markdown("Data provided by OpenF1 API | Dashboard built with Streamlit/Plotly")  #
 
 
 # Optional: Test API connection button (Original app.py had a test in main)
 # if st.sidebar.button("Test API Connection"):
 #     with st.spinner("Testing API connection..."):
 #         # The api.test_api_connection() function prints to console
-#         if api.test_api_connection(): 
+#         if api.test_api_connection():
 #             st.sidebar.success("API connection successful! Check console for details.")
 #         else:
 #             st.sidebar.error("API connection failed. Check console for details.")

--- a/visualizers.py
+++ b/visualizers.py
@@ -5,27 +5,8 @@ import pandas as pd
 from plotly.graph_objects import Figure
 import numpy as np
 
-# Color schemes for different teams/compounds
-TEAM_COLORS = {
-    'Red Bull Racing': '#1E41FF',
-    'Mercedes': '#00D2BE', 
-    'Ferrari': '#DC143C',
-    'McLaren': '#FF8700',
-    'Alpine': '#0090FF',
-    'Aston Martin': '#006F62',
-    'Williams': '#005AFF',
-    'AlphaTauri': '#2B4562',
-    'Alfa Romeo': '#900000',
-    'Haas': '#FFFFFF'
-}
+from viz_utils import TEAM_COLORS, COMPOUND_COLORS, apply_plot_style
 
-COMPOUND_COLORS = {
-    'SOFT': '#FF3333',
-    'MEDIUM': '#FFD700', 
-    'HARD': '#FFFFFF',
-    'INTERMEDIATE': '#00FF00',
-    'WET': '#0066FF'
-}
 
 def format_time_axis(seconds_series):
     """Format seconds to MM:SS.mmm for axis labels."""
@@ -33,157 +14,232 @@ def format_time_axis(seconds_series):
         return []
     return [f"{int(s//60)}:{s%60:06.3f}" if pd.notna(s) else "" for s in seconds_series]
 
+
 # Phase 1 visualizers
 def plot_lap_trend(df: pd.DataFrame) -> Figure:
     """Plot lap time trend with enhanced styling."""
     if df.empty:
-        return go.Figure().add_annotation(text="No data available", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
+        return go.Figure().add_annotation(
+            text="No data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
     # Convert lap_duration to seconds if needed
-    if 'lap_duration' in df.columns:
+    if "lap_duration" in df.columns:
         df = df.copy()
-        if df['lap_duration'].dtype == 'object':
-            df['lap_duration_seconds'] = df['lap_duration'].apply(lambda x: 
-                float(x.split(':')[0]) * 60 + float(x.split(':')[1]) if ':' in str(x) else float(x))
+        if df["lap_duration"].dtype == "object":
+            df["lap_duration_seconds"] = df["lap_duration"].apply(
+                lambda x: (
+                    float(x.split(":")[0]) * 60 + float(x.split(":")[1])
+                    if ":" in str(x)
+                    else float(x)
+                )
+            )
         else:
-            df['lap_duration_seconds'] = df['lap_duration']
-    
-    fig = px.line(df, x="lap_number", y="lap_duration_seconds", 
-                  title="🏁 Lap Time Trend",
-                  labels={"lap_number": "Lap Number", "lap_duration_seconds": "Lap Time (seconds)"})
-    
+            df["lap_duration_seconds"] = df["lap_duration"]
+
+    fig = px.line(
+        df,
+        x="lap_number",
+        y="lap_duration_seconds",
+        title="🏁 Lap Time Trend",
+        labels={
+            "lap_number": "Lap Number",
+            "lap_duration_seconds": "Lap Time (seconds)",
+        },
+    )
+
     # Add moving average
     if len(df) > 3:
-        df['moving_avg'] = df['lap_duration_seconds'].rolling(window=3, center=True).mean()
-        fig.add_scatter(x=df['lap_number'], y=df['moving_avg'], 
-                       mode='lines', name='3-lap moving average',
-                       line=dict(dash='dash', color='orange'))
-    
-    fig.update_layout(
-        template='plotly_white',
-        hovermode='x unified',
-        showlegend=True
-    )
-    
+        df["moving_avg"] = (
+            df["lap_duration_seconds"].rolling(window=3, center=True).mean()
+        )
+        fig.add_scatter(
+            x=df["lap_number"],
+            y=df["moving_avg"],
+            mode="lines",
+            name="3-lap moving average",
+            line=dict(dash="dash", color="orange"),
+        )
+
+    apply_plot_style(fig, showlegend=True)
+
     return fig
 
 
 def plot_distribution(df: pd.DataFrame) -> Figure:
     """Plot lap time distribution with statistics."""
     if df.empty:
-        return go.Figure().add_annotation(text="No data available", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
+        return go.Figure().add_annotation(
+            text="No data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
     # Convert to seconds
     df = df.copy()
-    if df['lap_duration'].dtype == 'object':
-        df['lap_duration_seconds'] = df['lap_duration'].apply(lambda x: 
-            float(x.split(':')[0]) * 60 + float(x.split(':')[1]) if ':' in str(x) else float(x))
+    if df["lap_duration"].dtype == "object":
+        df["lap_duration_seconds"] = df["lap_duration"].apply(
+            lambda x: (
+                float(x.split(":")[0]) * 60 + float(x.split(":")[1])
+                if ":" in str(x)
+                else float(x)
+            )
+        )
     else:
-        df['lap_duration_seconds'] = df['lap_duration']
-    
+        df["lap_duration_seconds"] = df["lap_duration"]
+
     # Filter out outliers
-    valid_times = df['lap_duration_seconds'].dropna()
+    valid_times = df["lap_duration_seconds"].dropna()
     if valid_times.empty:
-        return go.Figure().add_annotation(text="No valid lap times", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
-    fig = px.histogram(df, x="lap_duration_seconds", nbins=20, 
-                      title="📊 Lap Time Distribution",
-                      labels={"lap_duration_seconds": "Lap Time (seconds)"})
-    
+        return go.Figure().add_annotation(
+            text="No valid lap times",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
+    fig = px.histogram(
+        df,
+        x="lap_duration_seconds",
+        nbins=20,
+        title="📊 Lap Time Distribution",
+        labels={"lap_duration_seconds": "Lap Time (seconds)"},
+    )
+
     # Add statistical lines
     mean_time = valid_times.mean()
     median_time = valid_times.median()
-    
-    fig.add_vline(x=mean_time, line_dash="dash", line_color="red", 
-                  annotation_text=f"Mean: {mean_time:.3f}s")
-    fig.add_vline(x=median_time, line_dash="dot", line_color="blue",
-                  annotation_text=f"Median: {median_time:.3f}s")
-    
-    fig.update_layout(template='plotly_white')
+
+    fig.add_vline(
+        x=mean_time,
+        line_dash="dash",
+        line_color="red",
+        annotation_text=f"Mean: {mean_time:.3f}s",
+    )
+    fig.add_vline(
+        x=median_time,
+        line_dash="dot",
+        line_color="blue",
+        annotation_text=f"Median: {median_time:.3f}s",
+    )
+
+    apply_plot_style(fig, showlegend=False)
     return fig
 
 
 def plot_delta(df: pd.DataFrame) -> Figure:
     """Plot lap-by-lap delta vs teammate."""
     if df.empty:
-        return go.Figure().add_annotation(text="No teammate comparison data", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
+        return go.Figure().add_annotation(
+            text="No teammate comparison data",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
     # Create color based on positive/negative delta
-    colors = ['red' if x > 0 else 'green' for x in df['delta']]
-    
+    colors = ["red" if x > 0 else "green" for x in df["delta"]]
+
     fig = go.Figure()
-    fig.add_bar(x=df['lap_number'], y=df['delta'], 
-               marker_color=colors,
-               name='Delta vs Teammate')
-    
+    fig.add_bar(
+        x=df["lap_number"], y=df["delta"], marker_color=colors, name="Delta vs Teammate"
+    )
+
     # Add zero line
     fig.add_hline(y=0, line_dash="dash", line_color="black", opacity=0.5)
-    
+
     fig.update_layout(
         title="⚖️ Lap-by-Lap Delta vs. Teammate",
         xaxis_title="Lap Number",
         yaxis_title="Delta (seconds)",
-        template='plotly_white',
         annotations=[
-            dict(text="Faster", x=0.02, y=0.98, xref="paper", yref="paper", 
-                 showarrow=False, font=dict(color="green")),
-            dict(text="Slower", x=0.02, y=0.02, xref="paper", yref="paper",
-                 showarrow=False, font=dict(color="red"))
-        ]
+            dict(
+                text="Faster",
+                x=0.02,
+                y=0.98,
+                xref="paper",
+                yref="paper",
+                showarrow=False,
+                font=dict(color="green"),
+            ),
+            dict(
+                text="Slower",
+                x=0.02,
+                y=0.02,
+                xref="paper",
+                yref="paper",
+                showarrow=False,
+                font=dict(color="red"),
+            ),
+        ],
     )
-    
+    apply_plot_style(fig)
+
     return fig
+
 
 # Phase 2 visualizers
 def plot_team_comparison(df: pd.DataFrame) -> Figure:
     """Enhanced team comparison with multiple metrics."""
     if df.empty:
-        return go.Figure().add_annotation(text="No team data available", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
+        return go.Figure().add_annotation(
+            text="No team data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
     # Calculate team averages
-    team_avg = df.groupby("team_name").agg({
-        'avg_lap': 'mean',
-        'fastest_lap': 'min',
-        'consistency': 'mean'
-    }).reset_index()
-    
+    team_avg = (
+        df.groupby("team_name")
+        .agg({"avg_lap": "mean", "fastest_lap": "min", "consistency": "mean"})
+        .reset_index()
+    )
+
     # Sort by average lap time
-    team_avg = team_avg.sort_values('avg_lap')
-    
+    team_avg = team_avg.sort_values("avg_lap")
+
     # Create colors based on team
-    colors = [TEAM_COLORS.get(team, '#888888') for team in team_avg['team_name']]
-    
+    colors = [TEAM_COLORS.get(team, "#888888") for team in team_avg["team_name"]]
+
     fig = go.Figure()
-    fig.add_bar(x=team_avg['team_name'], y=team_avg['avg_lap'],
-               marker_color=colors,
-               name='Average Lap Time',
-               text=[f"{t:.3f}s" for t in team_avg['avg_lap']],
-               textposition='outside')
-    
+    fig.add_bar(
+        x=team_avg["team_name"],
+        y=team_avg["avg_lap"],
+        marker_color=colors,
+        name="Average Lap Time",
+        text=[f"{t:.3f}s" for t in team_avg["avg_lap"]],
+        textposition="outside",
+    )
+
     fig.update_layout(
         title="🏆 Average Lap Time by Team",
         xaxis_title="Team",
         yaxis_title="Average Lap Time (seconds)",
-        template='plotly_white',
-        xaxis_tickangle=-45
+        xaxis_tickangle=-45,
     )
-    
+    apply_plot_style(fig)
+
     return fig
 
 
 def plot_team_pace(df: pd.DataFrame) -> Figure:
     """Bar chart ranking teams by average pace."""
-    if df.empty or 'team_name' not in df.columns:
+    if df.empty or "team_name" not in df.columns:
         return go.Figure().add_annotation(
             text="No team pace data available",
             xref="paper",
@@ -206,199 +262,257 @@ def plot_team_pace(df: pd.DataFrame) -> Figure:
         title="🚥 Team Pace Ranking",
         xaxis_title="Team",
         yaxis_title="Average Lap Time (seconds)",
-        template="plotly_white",
         xaxis_tickangle=-45,
     )
+    apply_plot_style(fig)
     return fig
 
 
 def plot_pace_by_compound(df: pd.DataFrame) -> Figure:
     """Box plot showing pace by tyre compound."""
     if df.empty:
-        return go.Figure().add_annotation(text="No tyre compound data", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
-    fig = px.box(df, x="compound", y="lap_duration_seconds", 
-                 title="🏎️ Lap Time by Tyre Compound",
-                 labels={"compound": "Tyre Compound", "lap_duration_seconds": "Lap Time (seconds)"},
-                 color="compound",
-                 color_discrete_map=COMPOUND_COLORS)
-    
-    fig.update_layout(template='plotly_white', showlegend=False)
+        return go.Figure().add_annotation(
+            text="No tyre compound data",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
+    fig = px.box(
+        df,
+        x="compound",
+        y="lap_duration_seconds",
+        title="🏎️ Lap Time by Tyre Compound",
+        labels={
+            "compound": "Tyre Compound",
+            "lap_duration_seconds": "Lap Time (seconds)",
+        },
+        color="compound",
+        color_discrete_map=COMPOUND_COLORS,
+    )
+
+    apply_plot_style(fig, showlegend=False)
     return fig
 
 
 def plot_degradation_curves(df: pd.DataFrame) -> Figure:
     """Plot tyre degradation curves by compound."""
     if df.empty:
-        return go.Figure().add_annotation(text="No degradation data available", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
-    fig = px.scatter(df, x="tyre_age", y="lap_duration_seconds", 
-                    color="compound", 
-                    title="📉 Tyre Degradation Curves",
-                    labels={"tyre_age": "Tyre Age (laps)", "lap_duration_seconds": "Lap Time (seconds)"},
-                    color_discrete_map=COMPOUND_COLORS,
-                    trendline="lowess")
-    
-    fig.update_layout(template='plotly_white')
+        return go.Figure().add_annotation(
+            text="No degradation data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
+    fig = px.scatter(
+        df,
+        x="tyre_age",
+        y="lap_duration_seconds",
+        color="compound",
+        title="📉 Tyre Degradation Curves",
+        labels={
+            "tyre_age": "Tyre Age (laps)",
+            "lap_duration_seconds": "Lap Time (seconds)",
+        },
+        color_discrete_map=COMPOUND_COLORS,
+        trendline="lowess",
+    )
+
+    apply_plot_style(fig)
     return fig
 
 
 def plot_stint_timeline(stints: pd.DataFrame) -> Figure:
     """Gantt-style timeline showing driver stints."""
     if stints.empty:
-        return go.Figure().add_annotation(text="No stint data available", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
+        return go.Figure().add_annotation(
+            text="No stint data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
     fig = px.timeline(
         stints,
         x_start="lap_start",
-        x_end="lap_end", 
+        x_end="lap_end",
         y="driver_number",
         color="compound",
         title="🔄 Driver Stint Timeline",
         labels={"driver_number": "Driver #"},
-        color_discrete_map=COMPOUND_COLORS
+        color_discrete_map=COMPOUND_COLORS,
     )
-    
-    fig.update_yaxes(title="Driver Number", type='category')
+
+    fig.update_yaxes(title="Driver Number", type="category")
     fig.update_xaxes(title="Lap Number")
-    fig.update_layout(template='plotly_white')
-    
+    apply_plot_style(fig, showlegend=False)
+
     return fig
+
 
 # Phase 3 visualizers
 def plot_sector_table(df: pd.DataFrame) -> Figure:
     """Sector performance comparison table/chart."""
     if df.empty:
-        return go.Figure().add_annotation(text="No sector data available", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
+        return go.Figure().add_annotation(
+            text="No sector data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
     # Create subplots for each sector
     fig = make_subplots(
-        rows=1, cols=3,
+        rows=1,
+        cols=3,
         subplot_titles=("Sector 1", "Sector 2", "Sector 3"),
-        shared_yaxes=True
+        shared_yaxes=True,
     )
-    
-    sectors = ['best_s1', 'best_s2', 'best_s3']
-    colors = ['red', 'yellow', 'green']
-    
+
+    sectors = ["best_s1", "best_s2", "best_s3"]
+    colors = ["red", "yellow", "green"]
+
     for i, (sector, color) in enumerate(zip(sectors, colors)):
         if sector in df.columns:
             fig.add_bar(
-                x=df['driver_number'],
+                x=df["driver_number"],
                 y=df[sector],
-                name=f'Sector {i+1}',
+                name=f"Sector {i+1}",
                 marker_color=color,
-                row=1, col=i+1
+                row=1,
+                col=i + 1,
             )
-    
+
     fig.update_layout(
         title="⏱️ Best Sector Times by Driver",
-        template='plotly_white',
-        showlegend=False
     )
-    
+    apply_plot_style(fig, showlegend=False)
+
     return fig
 
 
 def plot_pit_durations(df: pd.DataFrame) -> Figure:
     """Plot pit stop duration analysis."""
     if df.empty:
-        return go.Figure().add_annotation(text="No pit stop data available", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
+        return go.Figure().add_annotation(
+            text="No pit stop data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
     fig = go.Figure()
-    
+
     # Average pit time bars
-    fig.add_bar(x=df['driver_number'], y=df['avg_pit'],
-               name='Average Pit Time',
-               marker_color='lightblue',
-               error_y=dict(
-                   type='data',
-                   array=df['max_pit'] - df['avg_pit'],
-                   arrayminus=df['avg_pit'] - df['min_pit'],
-                   visible=True
-               ))
-    
+    fig.add_bar(
+        x=df["driver_number"],
+        y=df["avg_pit"],
+        name="Average Pit Time",
+        marker_color="lightblue",
+        error_y=dict(
+            type="data",
+            array=df["max_pit"] - df["avg_pit"],
+            arrayminus=df["avg_pit"] - df["min_pit"],
+            visible=True,
+        ),
+    )
+
     # Best pit time line
-    fig.add_scatter(x=df['driver_number'], y=df['min_pit'],
-                   mode='markers+lines',
-                   name='Best Pit Time',
-                   marker=dict(color='green', size=8),
-                   line=dict(color='green', dash='dot'))
-    
+    fig.add_scatter(
+        x=df["driver_number"],
+        y=df["min_pit"],
+        mode="markers+lines",
+        name="Best Pit Time",
+        marker=dict(color="green", size=8),
+        line=dict(color="green", dash="dot"),
+    )
+
     fig.update_layout(
         title="🔧 Pit Stop Duration Analysis",
         xaxis_title="Driver Number",
         yaxis_title="Pit Duration (seconds)",
-        template='plotly_white',
-        legend=dict(x=0.7, y=0.95)
+        legend=dict(x=0.7, y=0.95),
     )
-    
+    apply_plot_style(fig)
+
     return fig
 
 
 def plot_performance_radar(driver_stats: dict, teammate_stats: dict = None) -> Figure:
     """Create a radar chart comparing driver performance metrics."""
     if not driver_stats:
-        return go.Figure().add_annotation(text="No performance data available", 
-                                        xref="paper", yref="paper",
-                                        x=0.5, y=0.5, showarrow=False)
-    
-    categories = ['Pace', 'Consistency', 'Sector 1', 'Sector 2', 'Sector 3', 'Pit Stops']
-    
+        return go.Figure().add_annotation(
+            text="No performance data available",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+        )
+
+    categories = [
+        "Pace",
+        "Consistency",
+        "Sector 1",
+        "Sector 2",
+        "Sector 3",
+        "Pit Stops",
+    ]
+
     # Normalize stats to 0-1 scale for radar chart
     values = [
-        1 - (driver_stats.get('avg_lap', 90) - 80) / 20,  # Pace (inverted, faster = better)
-        1 - driver_stats.get('consistency', 5) / 10,       # Consistency (inverted)
-        1 - (driver_stats.get('best_s1', 30) - 20) / 20,  # Sector times (inverted)
-        1 - (driver_stats.get('best_s2', 30) - 20) / 20,
-        1 - (driver_stats.get('best_s3', 30) - 20) / 20, 
-        1 - (driver_stats.get('avg_pit', 25) - 20) / 10   # Pit stops (inverted)
+        1
+        - (driver_stats.get("avg_lap", 90) - 80)
+        / 20,  # Pace (inverted, faster = better)
+        1 - driver_stats.get("consistency", 5) / 10,  # Consistency (inverted)
+        1 - (driver_stats.get("best_s1", 30) - 20) / 20,  # Sector times (inverted)
+        1 - (driver_stats.get("best_s2", 30) - 20) / 20,
+        1 - (driver_stats.get("best_s3", 30) - 20) / 20,
+        1 - (driver_stats.get("avg_pit", 25) - 20) / 10,  # Pit stops (inverted)
     ]
-    
+
     fig = go.Figure()
-    
-    fig.add_trace(go.Scatterpolar(
-        r=values,
-        theta=categories,
-        fill='toself',
-        name='Driver Performance'
-    ))
-    
+
+    fig.add_trace(
+        go.Scatterpolar(
+            r=values, theta=categories, fill="toself", name="Driver Performance"
+        )
+    )
+
     if teammate_stats:
         teammate_values = [
-            1 - (teammate_stats.get('avg_lap', 90) - 80) / 20,
-            1 - teammate_stats.get('consistency', 5) / 10,
-            1 - (teammate_stats.get('best_s1', 30) - 20) / 20,
-            1 - (teammate_stats.get('best_s2', 30) - 20) / 20,
-            1 - (teammate_stats.get('best_s3', 30) - 20) / 20,
-            1 - (teammate_stats.get('avg_pit', 25) - 20) / 10
+            1 - (teammate_stats.get("avg_lap", 90) - 80) / 20,
+            1 - teammate_stats.get("consistency", 5) / 10,
+            1 - (teammate_stats.get("best_s1", 30) - 20) / 20,
+            1 - (teammate_stats.get("best_s2", 30) - 20) / 20,
+            1 - (teammate_stats.get("best_s3", 30) - 20) / 20,
+            1 - (teammate_stats.get("avg_pit", 25) - 20) / 10,
         ]
-        
-        fig.add_trace(go.Scatterpolar(
-            r=teammate_values,
-            theta=categories,
-            fill='toself',
-            name='Teammate Performance'
-        ))
-    
+
+        fig.add_trace(
+            go.Scatterpolar(
+                r=teammate_values,
+                theta=categories,
+                fill="toself",
+                name="Teammate Performance",
+            )
+        )
+
     fig.update_layout(
-        polar=dict(
-            radialaxis=dict(
-                visible=True,
-                range=[0, 1]
-            )),
+        polar=dict(radialaxis=dict(visible=True, range=[0, 1])),
         title="🎯 Performance Radar Comparison",
-        template='plotly_white'
     )
-    
+    apply_plot_style(fig)
+
     return fig

--- a/viz_utils.py
+++ b/viz_utils.py
@@ -1,0 +1,33 @@
+import plotly.graph_objects as go
+
+# Central color schemes used across visualizers
+TEAM_COLORS = {
+    "Red Bull Racing": "#1E41FF",
+    "Mercedes": "#00D2BE",
+    "Ferrari": "#DC143C",
+    "McLaren": "#FF8700",
+    "Alpine": "#0090FF",
+    "Aston Martin": "#006F62",
+    "Williams": "#005AFF",
+    "AlphaTauri": "#2B4562",
+    "Alfa Romeo": "#900000",
+    "Haas": "#FFFFFF",
+}
+
+COMPOUND_COLORS = {
+    "SOFT": "#FF3333",
+    "MEDIUM": "#FFD700",
+    "HARD": "#FFFFFF",
+    "INTERMEDIATE": "#00FF00",
+    "WET": "#0066FF",
+}
+
+
+def apply_plot_style(
+    fig: go.Figure, *, showlegend: bool = True, hovermode: str = "x unified"
+) -> go.Figure:
+    """Apply common layout styling to a Plotly figure."""
+    fig.update_layout(
+        template="plotly_white", hovermode=hovermode, showlegend=showlegend
+    )
+    return fig


### PR DESCRIPTION
## Summary
- centralize Plotly styles and color maps in `viz_utils`
- update all visualizers to use `apply_plot_style`
- fetch dataframes with `api.models_to_dataframe` in `app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe47d0dcc83278440bd2ebb8fc335